### PR TITLE
Corrección del video teórico, en size() y height() 

### DIFF
--- a/src/ayp2/clase12/binaryTree/BinaryNode.java
+++ b/src/ayp2/clase12/binaryTree/BinaryNode.java
@@ -22,7 +22,7 @@ public class BinaryNode<T> {
 		if (left != null)
 			size += left.size();
 		if (right != null)
-			size += left.size();
+			size += right.size();
 		return size;
 	}
 
@@ -32,7 +32,7 @@ public class BinaryNode<T> {
 		if (left != null)
 			leftHeight = left.height();
 		if (right != null)
-			rightHeight = left.height();
+			rightHeight = right.height();
 		return 1 + Math.max(leftHeight, rightHeight);
 	}
 


### PR DESCRIPTION
Corrección del video teórico, en size() y height() en los if internos de los métodos se tomaba para ambos lados del árbol al lado izquierdo.